### PR TITLE
fix: align footer to bottom of page without overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,10 @@
             flex-direction: column;
             justify-content: flex-start;
             align-items: center;
-            min-height: 200vh;
+            min-height: 100vh;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             padding: 20px;
-            padding-bottom: 80px;
+            padding-bottom: 20px;
         }
 
         .login-container {
@@ -781,7 +781,8 @@
 
         /* FOOTER SECTION */
         footer {
-            position: fixed;
+            margin-top: 5%;
+            /* position: fixed; */
             bottom: 0;
             left: 0;
             width: 100%;


### PR DESCRIPTION
**Description**
- Fixed footer alignment issue
- Footer now stays at the bottom when content is short
- Footer naturally moves below content when the page is long

**Before**
<img width="500" height="860" alt="Screenshot 2025-09-19 193804" src="https://github.com/user-attachments/assets/46538f8b-1609-49dc-bf6f-0daf55ed9eef" />

**After**
<img width="500" height="864" alt="image" src="https://github.com/user-attachments/assets/d1f60d5e-2f90-4812-ac62-1ebd087cabed" />

